### PR TITLE
MAP-8 Mobile Device Gestures

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:unit": "vue-cli-service test:unit"
   },
   "dependencies": {
+    "hammerjs": "^2.0.8",
     "normalize.css": "^8.0.1",
     "register-service-worker": "^1.5.2",
     "vue": "^2.6.6",

--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -9,28 +9,37 @@
 aside {
   background: white;
   height: 100px;
+  transition: height 0.2s ease-in-out;
 
   @media (min-width: $breakpoint-tablet-portrait) {
     min-width: 340px;
     height: unset;
+  }
 
-    &.expanded {
+  &.expanded {
+    height: 100%;
+
+    @media (min-width: $breakpoint-tablet-portrait) {
       height: unset;
     }
   }
+}
 
-  .handle-drag {
-    background: $greyscale-0;
-    height: 10px;
-    border-radius: 3px 3px 0 0;
-    cursor: pointer;
+.handle-drag {
+  background: $greyscale-0;
+  height: 10px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  cursor: pointer;
+  transition: border-top-left-radius 0.2s ease-in-out, border-top-right-radius 0.2s ease-in-out;
 
-    @media (min-width: $breakpoint-tablet-portrait) {
-      display: none;
-    }
+  .expanded & {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
   }
-  &.expanded {
-    height: 100%;
+
+  @media (min-width: $breakpoint-tablet-portrait) {
+    display: none;
   }
 }
 </style>

--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -1,5 +1,7 @@
 <template>
-  <aside></aside>
+  <aside v-expandable>
+
+  </aside>
 </template>
 <style scoped lang="scss">
 @import "../style/variables";
@@ -11,6 +13,29 @@ aside {
   @media (min-width: $breakpoint-tablet-portrait) {
     min-width: 340px;
     height: unset;
+
+    &.expanded {
+      height: unset;
+    }
+  }
+
+  .handle-drag {
+    background: $greyscale-0;
+    height: 10px;
+    border-radius: 3px 3px 0 0;
+    cursor: pointer;
+
+    @media (min-width: $breakpoint-tablet-portrait) {
+      display: none;
+    }
+  }
+  &.expanded {
+    height: 100%;
   }
 }
 </style>
+<script>
+import "../directives/expandable";
+
+export default {};
+</script>

--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -1,19 +1,21 @@
 <template>
-  <aside v-expandable>
-
-  </aside>
+  <aside v-expandable></aside>
 </template>
 <style scoped lang="scss">
 @import "../style/variables";
 
 aside {
   background: white;
-  height: 100px;
+  height: 50px;
   transition: height 0.2s ease-in-out;
 
   @media (min-width: $breakpoint-tablet-portrait) {
     min-width: 340px;
     height: unset;
+  }
+
+  &.expanding {
+    transition: unset;
   }
 
   &.expanded {
@@ -33,6 +35,7 @@ aside {
   cursor: pointer;
   transition: border-top-left-radius 0.2s ease-in-out, border-top-right-radius 0.2s ease-in-out;
 
+  .expanding &,
   .expanded & {
     border-top-left-radius: 0;
     border-top-right-radius: 0;

--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -6,7 +6,7 @@
 
 aside {
   background: white;
-  height: 50px;
+  height: 100px;
   transition: height 0.2s ease-in-out;
 
   @media (min-width: $breakpoint-tablet-portrait) {
@@ -28,12 +28,27 @@ aside {
 }
 
 .handle-drag {
+  position: relative;
   background: $greyscale-0;
   height: 10px;
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
   cursor: pointer;
   transition: border-top-left-radius 0.2s ease-in-out, border-top-right-radius 0.2s ease-in-out;
+
+  &::before,
+  &::after {
+    position: absolute;
+    content: " ";
+    width: 100%;
+    height: 10px;
+    bottom: 100%;
+  }
+
+  &::after {
+    bottom: unset;
+    top: 100%;
+  }
 
   .expanding &,
   .expanded & {

--- a/src/directives/expandable.js
+++ b/src/directives/expandable.js
@@ -1,0 +1,73 @@
+import Vue from "vue";
+import Hammer from "hammerjs";
+
+const CLASS_EXPANDED = "expanded";
+const CLASS_EXPANDING = "expanding";
+const CLASS_HANDLE_DRAG = "handle-drag";
+
+Vue.directive("expandable", {
+  bind(el, binding, vNode) {
+    const sidebarHammerInstance = Hammer(el);
+    sidebarHammerInstance.get("swipe").set({ direction: Hammer.DIRECTION_VERTICAL });
+
+    sidebarHammerInstance.on("swipeup", () => {
+      if (!el.classList.contains(CLASS_EXPANDED)) {
+        el.classList.add(CLASS_EXPANDED);
+      }
+    });
+
+    sidebarHammerInstance.on("swipedown", () => {
+      if (el.classList.contains(CLASS_EXPANDED)) {
+        el.classList.remove(CLASS_EXPANDED);
+      }
+    });
+
+    const dragHandle = document.createElement("div");
+    dragHandle.classList.add(CLASS_HANDLE_DRAG);
+    dragHandle.setAttribute(vNode.context.$options._scopeId, "");
+
+    el.prepend(dragHandle);
+
+    dragHandle.addEventListener("click", () => {
+      el.classList.toggle(CLASS_EXPANDED);
+    });
+
+    const dragHandleHammerInstance = Hammer(dragHandle);
+    dragHandleHammerInstance.get("pan").set({ direction: Hammer.DIRECTION_VERTICAL });
+
+    dragHandleHammerInstance.on("panStart", () => {
+      el.classList.add(CLASS_EXPANDING);
+    });
+
+    const minPanHeight = 100;
+
+    dragHandleHammerInstance.on("pan", panEvent => {
+      let temporaryHeight;
+
+      if (el.classList.contains(CLASS_EXPANDED)) {
+        temporaryHeight = window.innerHeight - panEvent.deltaY;
+      } else {
+        temporaryHeight = minPanHeight + Math.abs(panEvent.deltaY);
+      }
+
+      if (minPanHeight <= temporaryHeight && temporaryHeight <= window.innerHeight) {
+        el.style.height = `${temporaryHeight}px`;
+      }
+    });
+
+    dragHandleHammerInstance.on("panend", () => {
+      if (el.classList.contains(CLASS_EXPANDED)) {
+        if (el.offsetHeight <= (3 * window.innerHeight) / 4) {
+          el.classList.remove(CLASS_EXPANDED);
+        }
+      } else {
+        if (el.offsetHeight >= window.innerHeight / 3) {
+          el.classList.add(CLASS_EXPANDED);
+        }
+      }
+
+      el.classList.remove(CLASS_EXPANDING);
+      el.style.height = "";
+    });
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4391,6 +4391,11 @@ gzip-size@^5.0.0:
     duplexer "^0.1.1"
     pify "^3.0.0"
 
+hammerjs@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
+  integrity sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=
+
 handle-thing@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"


### PR DESCRIPTION
Implemented a directive that enables drag, swipe and tap to expand / collapse the sidebar.
- Adds a drag handle to the element
- Enables dragging the drag handle in order to expand / collapse the element: 1/3 window height for the expand / collapse to trigger automatically
- Enable swiping anywhere within the element to expand / collapse it
- Enables click / tap on the drag handle to expand / collapse the element
